### PR TITLE
fix: fix client 'retry' tag

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,9 +20,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	"io"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/cloudwego/hertz/pkg/network/standard"
@@ -288,7 +288,10 @@ func (c *Client) processEvent(msg []byte) (event *Event, err error) {
 		case bytes.HasPrefix(line, headerEvent):
 			e.Event = string(append([]byte(nil), trimHeader(len(headerEvent), line)...))
 		case bytes.HasPrefix(line, headerRetry):
-			e.Retry = binary.BigEndian.Uint64(append([]byte(nil), trimHeader(len(headerRetry), line)...))
+			e.Retry, err = strconv.ParseUint(b2s(append([]byte(nil), trimHeader(len(headerRetry), line)...)), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("process message `retry` failed, err is %s", err)
+			}
 		default:
 			// Ignore any garbage that doesn't match what we're looking for.
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -148,7 +148,7 @@ func publishMsgs(s *Stream, empty bool, count int) {
 		if empty {
 			s.Publish(&Event{Data: []byte("\n")})
 		} else {
-			s.Publish(&Event{Data: []byte("ping")})
+			s.Publish(&Event{Data: []byte("ping"), Retry: uint64(3000), Event: "test", ID: "1111"})
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
#### What this PR does / why we need it (en: English/zh: Chinese):
en: fix client 'retry' tag
zh: 修复了 client 获取读取消息 retry 字段会 panic 的问题

