### PR TITLE
feat: support specifying the request to be used each time the SSE stream is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ func main() {
 
 		// touch off when connected to the server
 		c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client1 connect to server %s success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client1 connect to server success")
 		})
 
 		// touch off when the connection is shutdown
 		c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client1 disconnect to server %s success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client1 disconnect to server success")
 		})
 
 		events := make(chan *sse.Event)
@@ -181,12 +181,12 @@ func main() {
 
 		// touch off when connected to the server
 		c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client2 %s connect to server success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client2 connect to server success")
 		})
 
 		// touch off when the connection is shutdown
 		c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client2 %s disconnect to server success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client2 disconnect to server success")
 		})
 
 		events := make(chan *sse.Event, 10)

--- a/README.md
+++ b/README.md
@@ -90,129 +90,160 @@ see: [examples/client/quickstart/main.go](examples/client/quickstart/main.go)
 package main
 
 import (
-  "context"
-  "sync"
-  "time"
+	"context"
+	"sync"
+	"time"
 
-  "github.com/cloudwego/hertz/pkg/common/hlog"
+	"github.com/cloudwego/hertz/pkg/app/client"
+	"github.com/cloudwego/hertz/pkg/common/hlog"
+	"github.com/cloudwego/hertz/pkg/protocol"
 
-  "github.com/hertz-contrib/sse"
+	"github.com/hertz-contrib/sse"
 )
 
 var wg sync.WaitGroup
 
 func main() {
-  wg.Add(2)
-  go func() {
-    c := sse.NewClient("http://127.0.0.1:8888/sse")
+	wg.Add(2)
+	go func() {
+		// create Hertz client 
+		hCli, err := client.NewClient()
+		if err != nil {
+			hlog.Errorf("create Hertz client failed, err: %v", err)
+			return
+		}
+		// inject Hertz client to create SSE client
+		c, err := sse.NewClientWithOptions(sse.WithHertzClient(hCli))
+		if err != nil {
+			hlog.Errorf("create SSE client failed, err: %v", err)
+			return
+		}
 
-    // touch off when connected to the server
-    c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
-      hlog.Infof("client1 connect to server %s success with %s method", c.GetURL(), c.GetMethod())
-    })
+		// touch off when connected to the server
+		c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
+			hlog.Infof("client1 connect to server %s success with %s method", c.GetURL(), c.GetMethod())
+		})
 
-    // touch off when the connection is shutdown
-    c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
-      hlog.Infof("client1 disconnect to server %s success with %s method", c.GetURL(), c.GetMethod())
-    })
+		// touch off when the connection is shutdown
+		c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
+			hlog.Infof("client1 disconnect to server %s success with %s method", c.GetURL(), c.GetMethod())
+		})
 
-    events := make(chan *sse.Event)
-    errChan := make(chan error)
-    ctx, cancel := context.WithCancel(context.Background())
-    go func() {
-      cErr := c.SubscribeWithContext(ctx, func(msg *sse.Event) {
-        if msg.Data != nil {
-          events <- msg
-          return
-        }
-      })
-      errChan <- cErr
-    }()
-    go func() {
-      time.Sleep(5 * time.Second)
-      cancel()
-      hlog.Info("client1 subscribe cancel")
-    }()
-    for {
-      select {
-      case e := <-events:
-        hlog.Infof("client1, %+v", e)
-      case err := <-errChan:
-        if err == nil {
-          hlog.Info("client1, ctx done, read stop")
-        } else {
-          hlog.CtxErrorf(ctx, "client1, err = %s", err.Error())
-        }
-        wg.Done()
-        return
-      }
-    }
-  }()
+		events := make(chan *sse.Event)
+		errChan := make(chan error)
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			// build the req sent with each SSE request	
+			req := &protocol.Request{}
+			req.SetRequestURI("http://127.0.0.1:8888/sse")
+			cErr := c.SubscribeWithContext(ctx, func(msg *sse.Event) {
+				if msg.Data != nil {
+					events <- msg
+					return
+				}
+			}, sse.WithRequest(req))
+			errChan <- cErr
+		}()
+		go func() {
+			time.Sleep(5 * time.Second)
+			cancel()
+			hlog.Info("client1 subscribe cancel")
+		}()
+		for {
+			select {
+			case e := <-events:
+				hlog.Infof("client1, %+v", e)
+			case err := <-errChan:
+				if err == nil {
+					hlog.Info("client1, ctx done, read stop")
+				} else {
+					hlog.CtxErrorf(ctx, "client1, err = %s", err.Error())
+				}
+				wg.Done()
+				return
+			}
+		}
+	}()
 
-  go func() {
-    c := sse.NewClient("http://127.0.0.1:8888/sse")
+	go func() {
+		// create Hertz client 
+		hCli, err := client.NewClient()
+		if err != nil {
+			hlog.Errorf("create Hertz client failed, err: %v", err)
+			return
+		}
+		// inject Hertz client to create SSE client
+		c, err := sse.NewClientWithOptions(sse.WithHertzClient(hCli))
+		if err != nil {
+			hlog.Errorf("create SSE client failed, err: %v", err)
+			return
+		}
 
-    // touch off when connected to the server
-    c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
-      hlog.Infof("client2 %s connect to server success with %s method", c.GetURL(), c.GetMethod())
-    })
+		// touch off when connected to the server
+		c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
+			hlog.Infof("client2 %s connect to server success with %s method", c.GetURL(), c.GetMethod())
+		})
 
-    // touch off when the connection is shutdown
-    c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
-      hlog.Infof("client2 %s disconnect to server success with %s method", c.GetURL(), c.GetMethod())
-    })
+		// touch off when the connection is shutdown
+		c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
+			hlog.Infof("client2 %s disconnect to server success with %s method", c.GetURL(), c.GetMethod())
+		})
 
-    events := make(chan *sse.Event, 10)
-    errChan := make(chan error)
-    go func() {
-      cErr := c.Subscribe(func(msg *sse.Event) {
-        if msg.Data != nil {
-          events <- msg
-          return
-        }
-      })
-      errChan <- cErr
-    }()
+		events := make(chan *sse.Event, 10)
+		errChan := make(chan error)
+		go func() {
+			// build the req sent with each SSE request	
+			req := &protocol.Request{}
+			req.SetRequestURI("http://127.0.0.1:8888/sse")
+			cErr := c.Subscribe(func(msg *sse.Event) {
+				if msg.Data != nil {
+					events <- msg
+					return
+				}
+			}, sse.WithRequest(req))
+			errChan <- cErr
+		}()
 
-    streamClosed := false
-    for {
-      select {
-      case e := <-events:
-        hlog.Infof("client2, %+v", e)
-        time.Sleep(2 * time.Second) // do something blocked
-        // When the event ends, you should break out of the loop.
-        if checkEventEnd(e) {
-          wg.Done()
-          return
-        }
-      case err := <-errChan:
-        if err == nil {
-          // err is nil means read io.EOF, stream is closed
-          streamClosed = true
-          hlog.Info("client2, stream closed")
-          // continue read channel events
-          continue
-        }
-        hlog.CtxErrorf(context.Background(), "client2, err = %s", err.Error())
-        wg.Done()
-        return
-      default:
-        if streamClosed {
-          hlog.Info("client2, events is empty and stream closed")
-          wg.Done()
-          return
-        }
-      }
-    }
-  }()
+		streamClosed := false
+		for {
+			select {
+			case e := <-events:
+				hlog.Infof("client2, %+v", e)
+				time.Sleep(2 * time.Second) // do something blocked
+				// When the event ends, you should break out of the loop.
+				if checkEventEnd(e) {
+					wg.Done()
+					return
+				}
+			case err := <-errChan:
+				if err == nil {
+					// err is nil means read io.EOF, stream is closed
+					streamClosed = true
+					hlog.Info("client2, stream closed")
+					// continue read channel events
+					continue
+				}
+				hlog.CtxErrorf(context.Background(), "client2, err = %s", err.Error())
+				wg.Done()
+				return
+			default:
+				if streamClosed {
+					hlog.Info("client2, events is empty and stream closed")
+					wg.Done()
+					return
+				}
+			}
+		}
+	}()
 
-  wg.Wait()
+	wg.Wait()
 }
 
 func checkEventEnd(e *sse.Event) bool {
-  // check e.Data or e.Event. It depends on the definition of the server
-  return e.Event == "end" || string(e.Data) == "end flag"
+	// check e.Data or e.Event. It depends on the definition of the server
+	return e.Event == "end" || string(e.Data) == "end flag"
 }
+
 ```
 
 ## Real-world examples

--- a/README_CN.md
+++ b/README_CN.md
@@ -119,12 +119,12 @@ func main() {
 
 		// 连接到服务端的时候触发
 		c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client1 connect to server %s success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client1 connect to server success")
 		})
 
 		// 服务端断开连接的时候触发
 		c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client1 disconnect to server %s success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client1 disconnect to server success")
 		})
 
 		events := make(chan *sse.Event)
@@ -179,12 +179,12 @@ func main() {
 
 		// 连接到服务端的时候触发
 		c.SetOnConnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client2 %s connect to server success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client2 connect to server success")
 		})
 
 		// 服务端断开连接的时候触发
 		c.SetDisconnectCallback(func(ctx context.Context, client *sse.Client) {
-			hlog.Infof("client2 %s disconnect to server success with %s method", c.GetURL(), c.GetMethod())
+			hlog.Infof("client2 disconnect to server success")
 		})
 
 		events := make(chan *sse.Event, 10)

--- a/client.go
+++ b/client.go
@@ -137,7 +137,7 @@ func (c *Client) SubscribeWithContext(ctx context.Context, handler func(msg *Eve
 	}()
 
 	if err = c.hertzClient.Do(ctx, req, resp); err != nil {
-		return err
+		return fmt.Errorf("[SSE] hertz client Do failed, err: %v", err)
 	}
 	if Callback := c.responseCallback; Callback != nil {
 		err = Callback(ctx, req, resp)
@@ -145,7 +145,7 @@ func (c *Client) SubscribeWithContext(ctx context.Context, handler func(msg *Eve
 			return err
 		}
 	} else if resp.StatusCode() != consts.StatusOK {
-		return fmt.Errorf("could not connect to stream code: %d", resp.StatusCode())
+		return fmt.Errorf("[SSE] resp status code expects 200 but got %d", resp.StatusCode())
 	}
 
 	reader := NewEventStreamReader(resp.BodyStream(), c.maxBufferSize)

--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"sync/atomic"
 
+	"github.com/cloudwego/hertz/pkg/common/config"
 	"github.com/cloudwego/hertz/pkg/network/standard"
 
 	"github.com/cloudwego/hertz/pkg/app/client"
@@ -92,8 +93,8 @@ func NewClientWithOptions(opts ...ClientOption) (*Client, error) {
 		cliIntf = defaultClient
 	}
 	// SSE must use the streaming read functionality
-	if hertzCli, ok := cliIntf.(*client.Client); ok {
-		hertzCli.GetOptions().ResponseBodyStream = true
+	if optionsGetter, ok := cliIntf.(interface{ GetOptions() *config.ClientOptions }); ok {
+		optionsGetter.GetOptions().ResponseBodyStream = true
 	}
 
 	c := &Client{

--- a/client.go
+++ b/client.go
@@ -65,7 +65,7 @@ type Client struct {
 var defaultClient, _ = client.NewClient(client.WithDialer(standard.NewDialer()), client.WithResponseBodyStream(true))
 
 // NewClient creates a new client
-// deprecated, pls use NewClientWithOptions
+// Deprecated, pls use NewClientWithOptions
 func NewClient(url string) *Client {
 	c := &Client{
 		url:           url,

--- a/client.go
+++ b/client.go
@@ -318,31 +318,6 @@ func (c *Client) GetLastEventID() []byte {
 	return c.lastEventID.Load().([]byte)
 }
 
-func (c *Client) request(ctx context.Context, req *protocol.Request, resp *protocol.Response) error {
-	req.SetMethod(c.method)
-	req.SetRequestURI(c.url)
-
-	req.Header.Set("Cache-Control", "no-cache")
-	req.Header.Set("Accept", "text/event-stream")
-	req.Header.Set("Connection", "keep-alive")
-
-	lastID, exists := c.lastEventID.Load().([]byte)
-	if exists && lastID != nil {
-		req.Header.Set(LastEventID, string(lastID))
-	}
-	// Add user specified headers
-	for k, v := range c.headers {
-		req.Header.Set(k, v)
-	}
-
-	if len(c.body) != 0 {
-		req.SetBody(c.body)
-	}
-
-	err := c.hertzClient.Do(ctx, req, resp)
-	return err
-}
-
 func (c *Client) processEvent(msg []byte) (event *Event, err error) {
 	var e Event
 

--- a/client_test.go
+++ b/client_test.go
@@ -289,8 +289,15 @@ func TestClientUnSubscribe(t *testing.T) {
 				}, sopts...)
 				assert.Nil(t, cErr)
 			}()
+			time.Sleep(1 * time.Second)
 			cancel()
-			time.Sleep(5 * time.Second)
+			time.Sleep(1 * time.Second)
+
+			// read data that already published into channel
+			_, _ = wait(events, time.Second*1)
+			_, _ = wait(events, time.Second*1)
+
+			// there is no event send to channel after calling cancel()
 			for i := 0; i < 5; i++ {
 				_, err := wait(events, time.Second*1)
 				assert.DeepEqual(t, errors.New("timeout"), err)

--- a/client_test.go
+++ b/client_test.go
@@ -207,13 +207,7 @@ func TestClientSubscribe(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			var req *protocol.Request
-			var sopts []SubscribeOption
 			cli := test.newCli(t)
-			if test.newReq != nil {
-				req = test.newReq()
-				sopts = append(sopts, WithRequest(req))
-			}
 
 			// running multiple SSE requests concurrently
 			var wg sync.WaitGroup
@@ -224,6 +218,12 @@ func TestClientSubscribe(t *testing.T) {
 					events := make(chan *Event)
 					var cErr error
 					go func() {
+						var req *protocol.Request
+						var sopts []SubscribeOption
+						if test.newReq != nil {
+							req = test.newReq()
+							sopts = append(sopts, WithRequest(req))
+						}
 						cErr = cli.Subscribe(func(msg *Event) {
 							if msg.Data != nil {
 								events <- msg

--- a/client_test.go
+++ b/client_test.go
@@ -422,7 +422,6 @@ func TestClientOnConnect(t *testing.T) {
 			assert.DeepEqual(t, struct{}{}, <-called)
 		})
 	}
-
 }
 
 func TestClientUnsubscribe401(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudwego/hertz/pkg/app/client"
+	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 
 	"github.com/cloudwego/hertz/pkg/app"
@@ -175,113 +177,296 @@ func wait(ch chan *Event, duration time.Duration) ([]byte, error) {
 func TestClientSubscribe(t *testing.T) {
 	go newServer(false, "8886")
 	time.Sleep(time.Second)
-	c := NewClient("http://127.0.0.1:8886/sse")
-
-	events := make(chan *Event)
-	var cErr error
-	go func() {
-		cErr = c.Subscribe(func(msg *Event) {
-			if msg.Data != nil {
-				events <- msg
-				return
-			}
-		})
-	}()
-
-	for i := 0; i < 5; i++ {
-		msg, err := wait(events, time.Second*1)
-		assert.Nil(t, err)
-		assert.DeepEqual(t, []byte(`ping`), msg)
+	tests := []struct {
+		desc   string
+		newCli func(t *testing.T) *Client
+		newReq func() *protocol.Request
+	}{
+		{
+			desc: "old interface",
+			newCli: func(t *testing.T) *Client {
+				return NewClient("http://127.0.0.1:8886/sse")
+			},
+		},
+		{
+			desc: "new interface",
+			newCli: func(t *testing.T) *Client {
+				hertzCli, err := client.NewClient()
+				assert.Nil(t, err)
+				cli, err := NewClientWithOptions(WithHertzClient(hertzCli))
+				assert.Nil(t, err)
+				return cli
+			},
+			newReq: func() *protocol.Request {
+				req := &protocol.Request{}
+				req.SetRequestURI("http://127.0.0.1:8886/sse")
+				return req
+			},
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var req *protocol.Request
+			var sopts []SubscribeOption
+			cli := test.newCli(t)
+			if test.newReq != nil {
+				req = test.newReq()
+				sopts = append(sopts, WithRequest(req))
+			}
 
-	assert.Nil(t, cErr)
+			events := make(chan *Event)
+			var cErr error
+			go func() {
+				cErr = cli.Subscribe(func(msg *Event) {
+					if msg.Data != nil {
+						events <- msg
+						return
+					}
+				}, sopts...)
+			}()
+
+			for i := 0; i < 5; i++ {
+				msg, err := wait(events, time.Second*1)
+				assert.Nil(t, err)
+				assert.DeepEqual(t, []byte(`ping`), msg)
+			}
+
+			assert.Nil(t, cErr)
+		})
+	}
 }
 
 func TestClientUnSubscribe(t *testing.T) {
 	go newServer(false, "8887")
 	time.Sleep(time.Second)
-	c := NewClient("http://127.0.0.1:8887/sse")
+	tests := []struct {
+		desc   string
+		newCli func(t *testing.T) *Client
+		newReq func() *protocol.Request
+	}{
+		{
+			desc: "old interface",
+			newCli: func(t *testing.T) *Client {
+				return NewClient("http://127.0.0.1:8887/sse")
+			},
+		},
+		{
+			desc: "new interface",
+			newCli: func(t *testing.T) *Client {
+				hertzCli, err := client.NewClient()
+				assert.Nil(t, err)
+				cli, err := NewClientWithOptions(WithHertzClient(hertzCli))
+				assert.Nil(t, err)
+				return cli
+			},
+			newReq: func() *protocol.Request {
+				req := &protocol.Request{}
+				req.SetRequestURI("http://127.0.0.1:8887/sse")
+				return req
+			},
+		},
+	}
 
-	events := make(chan *Event)
-	ctx, cancel := context.WithCancel(context.Background())
-	var cErr error
-	go func() {
-		cErr = c.SubscribeWithContext(ctx, func(msg *Event) {
-			if msg.Data != nil {
-				events <- msg
-				return
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var req *protocol.Request
+			var sopts []SubscribeOption
+			cli := test.newCli(t)
+			if test.newReq != nil {
+				req = test.newReq()
+				sopts = append(sopts, WithRequest(req))
+			}
+
+			events := make(chan *Event)
+			ctx, cancel := context.WithCancel(context.Background())
+			var cErr error
+			go func() {
+				cErr = cli.SubscribeWithContext(ctx, func(msg *Event) {
+					if msg.Data != nil {
+						events <- msg
+						return
+					}
+				}, sopts...)
+				assert.Nil(t, cErr)
+			}()
+			cancel()
+			time.Sleep(5 * time.Second)
+			for i := 0; i < 5; i++ {
+				_, err := wait(events, time.Second*1)
+				assert.DeepEqual(t, errors.New("timeout"), err)
 			}
 		})
-		assert.Nil(t, cErr)
-	}()
-	time.Sleep(1 * time.Second)
-	cancel()
-	time.Sleep(1 * time.Second)
-
-	// read data that already published into channel
-	_, _ = wait(events, time.Second*1)
-	_, _ = wait(events, time.Second*1)
-
-	// there is no event send to channel after calling cancel()
-	for i := 0; i < 5; i++ {
-		_, err := wait(events, time.Second*1)
-		assert.DeepEqual(t, errors.New("timeout"), err)
 	}
 }
 
 func TestClientSubscribeMultiline(t *testing.T) {
 	go newMultilineServer("9007")
 	time.Sleep(time.Second)
-	c := NewClient("http://127.0.0.1:9007/sse")
-
-	events := make(chan *Event)
-	var cErr error
-
-	go func() {
-		cErr = c.Subscribe(func(msg *Event) {
-			if msg.Data != nil {
-				events <- msg
-				return
-			}
-		})
-	}()
-
-	for i := 0; i < 5; i++ {
-		msg, err := wait(events, time.Second*1)
-		assert.Nil(t, err)
-		assert.DeepEqual(t, []byte(mldata), msg)
+	tests := []struct {
+		desc   string
+		newCli func(t *testing.T) *Client
+		newReq func() *protocol.Request
+	}{
+		{
+			desc: "old interface",
+			newCli: func(t *testing.T) *Client {
+				return NewClient("http://127.0.0.1:9007/sse")
+			},
+		},
+		{
+			desc: "new interface",
+			newCli: func(t *testing.T) *Client {
+				hertzCli, err := client.NewClient()
+				assert.Nil(t, err)
+				cli, err := NewClientWithOptions(WithHertzClient(hertzCli))
+				assert.Nil(t, err)
+				return cli
+			},
+			newReq: func() *protocol.Request {
+				req := &protocol.Request{}
+				req.SetRequestURI("http://127.0.0.1:9007/sse")
+				return req
+			},
+		},
 	}
 
-	assert.Nil(t, cErr)
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var req *protocol.Request
+			var sopts []SubscribeOption
+			cli := test.newCli(t)
+			if test.newReq != nil {
+				req = test.newReq()
+				sopts = append(sopts, WithRequest(req))
+			}
+
+			events := make(chan *Event)
+			var cErr error
+
+			go func() {
+				cErr = cli.Subscribe(func(msg *Event) {
+					if msg.Data != nil {
+						events <- msg
+						return
+					}
+				}, sopts...)
+			}()
+
+			for i := 0; i < 5; i++ {
+				msg, err := wait(events, time.Second*1)
+				assert.Nil(t, err)
+				assert.DeepEqual(t, []byte(mldata), msg)
+			}
+
+			assert.Nil(t, cErr)
+		})
+	}
 }
 
 func TestClientOnConnect(t *testing.T) {
 	go newServerOnConnect(false, "9000")
 	time.Sleep(time.Second)
-	c := NewClient("http://127.0.0.1:9000/sse")
+	tests := []struct {
+		desc   string
+		newCli func(t *testing.T) *Client
+		newReq func() *protocol.Request
+	}{
+		{
+			desc: "old interface",
+			newCli: func(t *testing.T) *Client {
+				return NewClient("http://127.0.0.1:9000/sse")
+			},
+		},
+		{
+			desc: "new interface",
+			newCli: func(t *testing.T) *Client {
+				hertzCli, err := client.NewClient()
+				assert.Nil(t, err)
+				cli, err := NewClientWithOptions(WithHertzClient(hertzCli))
+				assert.Nil(t, err)
+				return cli
+			},
+			newReq: func() *protocol.Request {
+				req := &protocol.Request{}
+				req.SetRequestURI("http://127.0.0.1:9000/sse")
+				return req
+			},
+		},
+	}
 
-	called := make(chan struct{})
-	c.SetOnConnectCallback(func(ctx context.Context, client *Client) {
-		called <- struct{}{}
-	})
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var req *protocol.Request
+			var sopts []SubscribeOption
+			cli := test.newCli(t)
+			if test.newReq != nil {
+				req = test.newReq()
+				sopts = append(sopts, WithRequest(req))
+			}
 
-	go c.Subscribe(func(msg *Event) {})
+			called := make(chan struct{})
+			cli.SetOnConnectCallback(func(ctx context.Context, client *Client) {
+				called <- struct{}{}
+			})
 
-	time.Sleep(time.Second)
-	assert.DeepEqual(t, struct{}{}, <-called)
+			go cli.Subscribe(func(msg *Event) {}, sopts...)
+
+			time.Sleep(time.Second)
+			assert.DeepEqual(t, struct{}{}, <-called)
+		})
+	}
+
 }
 
 func TestClientUnsubscribe401(t *testing.T) {
 	go newServer401("9009")
 	time.Sleep(time.Second)
-	c := NewClient("http://127.0.0.1:9009/sse")
+	tests := []struct {
+		desc   string
+		newCli func(t *testing.T) *Client
+		newReq func() *protocol.Request
+	}{
+		{
+			desc: "old interface",
+			newCli: func(t *testing.T) *Client {
+				return NewClient("http://127.0.0.1:9009/sse")
+			},
+		},
+		{
+			desc: "new interface",
+			newCli: func(t *testing.T) *Client {
+				hertzCli, err := client.NewClient()
+				assert.Nil(t, err)
+				cli, err := NewClientWithOptions(WithHertzClient(hertzCli))
+				assert.Nil(t, err)
+				return cli
+			},
+			newReq: func() *protocol.Request {
+				req := &protocol.Request{}
+				req.SetRequestURI("http://127.0.0.1:9009/sse")
+				return req
+			},
+		},
+	}
 
-	err := c.Subscribe(func(ev *Event) {
-		// this shouldn't run
-		assert.False(t, true)
-	})
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var req *protocol.Request
+			var sopts []SubscribeOption
+			cli := test.newCli(t)
+			if test.newReq != nil {
+				req = test.newReq()
+				sopts = append(sopts, WithRequest(req))
+			}
 
-	assert.NotNil(t, err)
+			err := cli.Subscribe(func(ev *Event) {
+				// this shouldn't run
+				assert.False(t, true)
+			}, sopts...)
+
+			assert.NotNil(t, err)
+		})
+	}
 }
 
 func TestClientLargeData(t *testing.T) {
@@ -290,21 +475,59 @@ func TestClientLargeData(t *testing.T) {
 	data = []byte(hex.EncodeToString(data))
 	go newServerBigData(data, "9005")
 	time.Sleep(time.Second)
-	c := NewClient("http://127.0.0.1:9005/sse")
+	tests := []struct {
+		desc   string
+		newCli func(t *testing.T) *Client
+		newReq func() *protocol.Request
+	}{
+		{
+			desc: "old interface",
+			newCli: func(t *testing.T) *Client {
+				return NewClient("http://127.0.0.1:9005/sse")
+			},
+		},
+		{
+			desc: "new interface",
+			newCli: func(t *testing.T) *Client {
+				hertzCli, err := client.NewClient()
+				assert.Nil(t, err)
+				cli, err := NewClientWithOptions(WithHertzClient(hertzCli))
+				assert.Nil(t, err)
+				return cli
+			},
+			newReq: func() *protocol.Request {
+				req := &protocol.Request{}
+				req.SetRequestURI("http://127.0.0.1:9005/sse")
+				return req
+			},
+		},
+	}
 
-	// limit retries to 3
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var req *protocol.Request
+			var sopts []SubscribeOption
+			cli := test.newCli(t)
+			if test.newReq != nil {
+				req = test.newReq()
+				sopts = append(sopts, WithRequest(req))
+			}
 
-	ec := make(chan *Event, 1)
+			// limit retries to 3
 
-	go func() {
-		c.Subscribe(func(ev *Event) {
-			ec <- ev
+			ec := make(chan *Event, 1)
+
+			go func() {
+				cli.Subscribe(func(ev *Event) {
+					ec <- ev
+				}, sopts...)
+			}()
+
+			d, err := wait(ec, time.Second)
+			assert.Nil(t, err)
+			assert.DeepEqual(t, data, d)
 		})
-	}()
-
-	d, err := wait(ec, time.Second)
-	assert.Nil(t, err)
-	assert.DeepEqual(t, data, d)
+	}
 }
 
 func TestTrimHeader(t *testing.T) {
@@ -335,25 +558,67 @@ func TestTrimHeader(t *testing.T) {
 func TestRequestWithBody(t *testing.T) {
 	go newServerWithPOSTBody(false, "9006")
 	time.Sleep(time.Second)
-	c := NewClient("http://127.0.0.1:9006/sse")
-	c.SetMethod(consts.MethodPost)
-	c.body = []byte(`{"msg":"echo"}`)
-	events := make(chan *Event)
-	var cErr error
-	go func() {
-		cErr = c.Subscribe(func(msg *Event) {
-			if msg.Data != nil {
-				events <- msg
-				return
-			}
-		})
-	}()
-
-	for i := 0; i < 5; i++ {
-		msg, err := wait(events, time.Second*1)
-		assert.Nil(t, err)
-		assert.DeepEqual(t, []byte(`{"msg":"echo"}`), msg)
+	tests := []struct {
+		desc   string
+		newCli func(t *testing.T) *Client
+		newReq func() *protocol.Request
+	}{
+		{
+			desc: "old interface",
+			newCli: func(t *testing.T) *Client {
+				cli := NewClient("http://127.0.0.1:9006/sse")
+				cli.SetMethod(consts.MethodPost)
+				cli.SetBody([]byte(`{"msg":"echo"}`))
+				return cli
+			},
+		},
+		{
+			desc: "new interface",
+			newCli: func(t *testing.T) *Client {
+				hertzCli, err := client.NewClient()
+				assert.Nil(t, err)
+				cli, err := NewClientWithOptions(WithHertzClient(hertzCli))
+				assert.Nil(t, err)
+				return cli
+			},
+			newReq: func() *protocol.Request {
+				req := &protocol.Request{}
+				req.SetRequestURI("http://127.0.0.1:9006/sse")
+				req.SetMethod(consts.MethodPost)
+				req.SetBody([]byte(`{"msg":"echo"}`))
+				return req
+			},
+		},
 	}
 
-	assert.Nil(t, cErr)
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var req *protocol.Request
+			var sopts []SubscribeOption
+			cli := test.newCli(t)
+			if test.newReq != nil {
+				req = test.newReq()
+				sopts = append(sopts, WithRequest(req))
+			}
+
+			events := make(chan *Event)
+			var cErr error
+			go func() {
+				cErr = cli.Subscribe(func(msg *Event) {
+					if msg.Data != nil {
+						events <- msg
+						return
+					}
+				}, sopts...)
+			}()
+
+			for i := 0; i < 5; i++ {
+				msg, err := wait(events, time.Second*1)
+				assert.Nil(t, err)
+				assert.DeepEqual(t, []byte(`{"msg":"echo"}`), msg)
+			}
+
+			assert.Nil(t, cErr)
+		})
+	}
 }

--- a/option.go
+++ b/option.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sse
+
+import (
+	"github.com/cloudwego/hertz/pkg/protocol"
+	do "github.com/cloudwego/hertz/pkg/protocol/client"
+)
+
+type ClientOptions struct {
+	hertzCli do.Doer
+}
+
+type ClientOption func(*ClientOptions)
+
+// WithHertzClient specifies the underlying Hertz Client
+func WithHertzClient(cli do.Doer) ClientOption {
+	return func(opts *ClientOptions) {
+		opts.hertzCli = cli
+	}
+}
+
+type SubscribeOptions struct {
+	req *protocol.Request
+}
+
+type SubscribeOption func(*SubscribeOptions)
+
+// WithRequest specifies the request sent by the Hertz Client each time Subscribe or SubscribeWithContext is performed.
+// Request-related configuration items set via client.SetXX will not take effect when WithRequest is specified:
+// (client.SetURL, client.SetBody, client.SetMethod, client.SetHeaders).
+func WithRequest(req *protocol.Request) SubscribeOption {
+	return func(opts *SubscribeOptions) {
+		opts.req = req
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: 
The current SSE Client experience is not consistent with Hertz Client:
1. the configuration hierarchy is not clear, URL, Body, Method, Headers and other request level configuration need to call the Client interface to set up.
2. Hertz Request's rich RequestOptions cannot be used to initiate SSE requests.
Based on the above inconsistencies, the following proposal is made:
##### Add new definitions
- ClientOptions/ClientOption and SubscribeOptions/SubscribeOption are responsible for Client-level configuration and requests, respectively

The `WithHertzClient` and `WithRequest` are used to inject Hertz Client and Hertz Request, reusing the basic capabilities provided by Hertz.
##### Interface Updates
- added `NewClientWithOptions(opts .... .ClientOption)`, deprecated `NewClient(url string)`

The standard way to build an SSE Client is:
```
import (
    ‘github.com/cloudwego/hertz/pkg/app/client’
    ‘github.com/hertz-contrib/sse’
)

hCli, err := client.NewClient()
cli, err := sse.NewClientWithOptions(sse.WithHertzClient(hCli))
```
- `Client.Subscribe` and `Client.SubscribeWithContext` receive the `opts . .SubscribeOption` parameter

The standard way to request SSE is:
```
import (
    ‘github.com/cloudwego/hertz/pkg/protocol’
    ‘github.com/hertz-contrib/sse’
)

req := &protocol.Request{}
err := cli.Subscribe(callback, sse.WithRequest(req))
```
- deprecate `Client.SetURL`, `Client.SetBody`, `Client.SetMethod`, `Client.SetHeaders`, `Client.GetURL`, `Client.GetHeaders`, `GetMethod`, `GetBody`

To ensure compatibility, these Set functions are still valid, once configured with `WithRequest`, the injected Hertz Request will have the highest priority, ignoring the configuration of these Set function injections.

When the corresponding Set function is deprecated, the Get method needs to be deprecated as well.

- deprecate `Client.SetHertzClient`, `Client.GetHertzClient`

Using`NewClientWithOptions(WithHertzClient(hCli))` to inject.

zh:
当前 SSE Client 的使用体验与 Hertz Client 并不一致：
1. 配置层次不清晰，URL, Body, Method, Headers 等请求级别的配置需要调用 Client 接口进行设置
2. 无法使用 Hertz Request 丰富的 RequestOptions 发起 SSE 请求
基于以上的不一致，提出以下提议：
##### 新增定义
- ClientOptions/ClientOption 与 SubscribeOptions/SubscribeOption

分别负责 Client 级别配置与请求级别配置。
其中`WithHertzClient`与`WithRequest`用于注入 Hertz Client 与 Hertz Request，复用 Hertz 提供的基础能力。
##### 接口更新
- 新增`NewClientWithOptions(opts ...ClientOption)`，废弃`NewClient(url string)`

构建 SSE Client 的标准方式为：
```
import (
    "github.com/cloudwego/hertz/pkg/app/client"
    "github.com/hertz-contrib/sse"
)

hCli, err := client.NewClient()
cli, err := sse.NewClientWithOptions(sse.WithHertzClient(hCli))
```
- `Client.Subscribe`与`Client.SubscribeWithContext`接收`opts ...SubscribeOption`参数

请求 SSE 的标准方式为：
```
import (
    "github.com/cloudwego/hertz/pkg/protocol"
    "github.com/hertz-contrib/sse"
)

req := &protocol.Request{}
err := cli.Subscribe(callback, sse.WithRequest(req))
```
- 废弃`Client.SetURL`, `Client.SetBody`, `Client.SetMethod`, `Client.SetHeaders`, `Client.GetURL`, `Client.GetHeaders`, `GetMethod`, `GetBody`

为了保证兼容性，这几个 Set 函数依然有效，一旦配置上`WithRequest`，注入的 Hertz Request 将具有最高优先级，无视这些 Set 函数注入的配置

对应的 Set 函数被废弃后，Get 方法也需要被废弃。

- 废弃`Client.SetHertzClient`, `Client.GetHertzClient`

使用`NewClientWithOptions(WithHertzClient(hCli))`进行注入

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
