### PR TITLE
fix: avoid splitting a single event into multiple lines with many unnecessary \r\n

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -38,6 +38,7 @@
 package sse
 
 import (
+	"bytes"
 	"io"
 	"reflect"
 	"strconv"
@@ -45,23 +46,34 @@ import (
 )
 
 func Encode(w io.Writer, e *Event) (err error) {
-	err = writeID(w, e.ID)
+	// w could be a ChunkedBodyWriter from resp.NewChunkedBodyWriter.
+	// For ChunkedBodyWriter, each call to Write writes to a new chunk.
+	// The content being written will be wrapped with \r\n before and after.
+	// This can cause the returned event to be split into many lines, like:
+	// id:\r\n\r\n1\r\n\r\n\n\r\n\r\nevent:\r\n\r\nmessage\r\n\r\n
+	// Some less robust SSE clients may be unable to handle events that are split in this way.
+	// So we need to ensure that each event is written in a single Write call.
+	buf := bytes.NewBuffer(nil)
+
+	err = writeID(buf, e.ID)
 	if err != nil {
 		return
 	}
-	err = writeEvent(w, e.Event)
+	err = writeEvent(buf, e.Event)
 	if err != nil {
 		return
 	}
-	err = writeRetry(w, e.Retry)
+	err = writeRetry(buf, e.Retry)
 	if err != nil {
 		return
 	}
-	err = writeData(w, e.Data)
+	err = writeData(buf, e.Data)
 	if err != nil {
 		return
 	}
-	return nil
+
+	_, err = buf.WriteTo(w)
+	return err
 }
 
 func writeID(w io.Writer, id string) (err error) {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -43,8 +43,10 @@ import (
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/common/json"
-
 	"github.com/cloudwego/hertz/pkg/common/test/assert"
+	"github.com/cloudwego/hertz/pkg/network"
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/cloudwego/hertz/pkg/protocol/http1/resp"
 )
 
 type myStruct struct {
@@ -257,4 +259,53 @@ func BenchmarkSimpleSSE(b *testing.B) {
 		})
 		buf.Reset()
 	}
+}
+
+func TestEncodeWithChunkedBodyWriter(t *testing.T) {
+	mw := &MockWriter{}
+
+	w := resp.NewChunkedBodyWriter(&protocol.Response{}, mw)
+	// Set discard and call Write to skip writing HTTP headers.
+	mw.SetDiscard(true)
+	_, _ = w.Write(nil)
+	mw.SetDiscard(false)
+
+	_ = Encode(w, &Event{
+		Event: "message",
+		ID:    "1",
+		Retry: 2,
+		Data:  []byte("test data"),
+	})
+
+	assert.DeepEqual(t, "\r\nid:1\nevent:message\nretry:2\ndata:test data\n\n\r\n", string(mw.Bytes()))
+}
+
+type MockWriter struct {
+	discard bool
+	buffer  bytes.Buffer
+}
+
+var _ network.Writer = (*MockWriter)(nil)
+
+func (w *MockWriter) Malloc(n int) (buf []byte, err error) {
+	return nil, nil
+}
+
+func (w *MockWriter) WriteBinary(b []byte) (n int, err error) {
+	if w.discard {
+		return len(b), nil
+	}
+	return w.buffer.Write(b)
+}
+
+func (w *MockWriter) Flush() error {
+	return nil
+}
+
+func (w *MockWriter) Bytes() []byte {
+	return w.buffer.Bytes()
+}
+
+func (w *MockWriter) SetDiscard(discard bool) {
+	w.discard = discard
 }


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

#### What this PR does / why we need it (en: English/zh: Chinese):

en: 

Since `NewStream` calls `resp.NewChunkedBodyWriter` to use it as a writer, when encoding an event into the writer, each call to `Write` writes to a new chunk, which means the content being written will be wrapped with \r\n before and after, like `id:\r\n\r\n1\r\n\r\n\n\r\n\r\nevent:\r\n\r\nmessage\r\n\r\n`.

Some less robust SSE clients may be unable to handle events that are split in this way.

It's so hard to find this since most clients work well with it, like Postman or curl.

#### Which issue(s) this PR fixes:

None.
